### PR TITLE
fix: Remove validação da rota de update do "Ad"

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -34,7 +34,6 @@ routes.post(
 )
 routes.put(
   '/ads/:id',
-  validate(validators.Ad),
   handle(controllers.AdController.update)
 )
 routes.delete('/ads/:id', handle(controllers.AdController.destroy))


### PR DESCRIPTION
@csorlandi , percebi um detalhe: o validador do `Ad` foi inserido como middleware na rota `/ads/:id`, como você pode ver abaixo. Porém, isso cria um problema: se o usuário for atualizar um `Ad` ele não conseguirá, a menos, que envie **necessariamente** os campos `title`, `description` e `price` no body da requisição. Ou seja, dessa forma, ele nunca poderá atualizar somente 1 desses campos, como o Diego mostra no vídeo inicialmente (enquanto ainda não havia inserido o validador). Mesmo que queira atualizar somente 1 campo, teria de enviar todos os campos no body da requisição. 

Talvez ele tenha inserido o validador nessa rota por engano. Veja aí se faz sentido. 

Vlw :metal: .